### PR TITLE
[#13] feat: 메인페이지 검색바 UI 구현 및 리액트훅폼으로 공통 폼 및 인풋 컴포넌트 구현

### DIFF
--- a/src/app/_components/Form/CommonForm.tsx
+++ b/src/app/_components/Form/CommonForm.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+interface CommonFormProps {
+  children: ReactNode;
+  onSubmit: () => void;
+  className: string;
+}
+
+function CommonForm({ children, onSubmit, className }: CommonFormProps) {
+  const method = useForm();
+  return (
+    <FormProvider {...method}>
+      <form className={className} onSubmit={method.handleSubmit(onSubmit)}>
+        {children}
+      </form>
+    </FormProvider>
+  );
+}
+
+export default CommonForm;

--- a/src/app/_components/Input/CommonInput.tsx
+++ b/src/app/_components/Input/CommonInput.tsx
@@ -1,0 +1,27 @@
+import { useFormContext } from 'react-hook-form';
+
+interface InputProps {
+  name: string;
+  type?: string;
+  placeholder: string;
+  className: string;
+}
+
+function CommonInput({
+  name,
+  type = 'text',
+  placeholder,
+  className,
+}: InputProps) {
+  const { register } = useFormContext();
+  return (
+    <input
+      {...register(name)}
+      type={type}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
+export default CommonInput;

--- a/src/app/_components/Input/DateInput.tsx
+++ b/src/app/_components/Input/DateInput.tsx
@@ -1,0 +1,17 @@
+import { IconCalendar } from '@/public/svgs';
+import CommonInput from './CommonInput';
+
+function DateInput() {
+  return (
+    <div className='flex-134 relative flex w-full gap-4pxr'>
+      <IconCalendar className='absolute left-16pxr top-16pxr ' />
+      <CommonInput
+        name='date'
+        placeholder='날짜를 선택해주세요'
+        className=' w-full rounded-[8px] bg-gray100 py-16pxr pl-44pxr pr-16pxr text-black placeholder-gray500 outline-none font-body2-semibold placeholder:font-body2'
+      />
+    </div>
+  );
+}
+
+export default DateInput;

--- a/src/app/_components/Input/GroupCountInput.tsx
+++ b/src/app/_components/Input/GroupCountInput.tsx
@@ -1,0 +1,17 @@
+import { IconPeople } from '@/public/svgs';
+import CommonInput from './CommonInput';
+
+function GroupCountInput() {
+  return (
+    <div className='flex-123 relative flex w-full gap-4pxr'>
+      <IconPeople className='absolute left-16pxr top-16pxr ' />
+      <CommonInput
+        name='groupCount'
+        placeholder='참여 그룹을 설정해주세요'
+        className=' w-full rounded-[8px] bg-gray100 py-16pxr pl-44pxr pr-16pxr text-black placeholder-gray500 outline-none font-body2-semibold placeholder:font-body2'
+      />
+    </div>
+  );
+}
+
+export default GroupCountInput;

--- a/src/app/_components/Input/LocationInput.tsx
+++ b/src/app/_components/Input/LocationInput.tsx
@@ -1,0 +1,17 @@
+import { IconLocation } from '@/public/svgs';
+import CommonInput from './CommonInput';
+
+function LocationInput() {
+  return (
+    <div className='flex-110 relative flex w-full gap-4pxr'>
+      <IconLocation className='absolute left-16pxr top-16pxr ' />
+      <CommonInput
+        name='location'
+        placeholder='어디로 갈까요?'
+        className=' w-full rounded-lg bg-gray100 py-16pxr pl-44pxr pr-16pxr text-black placeholder-gray500 outline-none font-body2-semibold placeholder:font-body2'
+      />
+    </div>
+  );
+}
+
+export default LocationInput;

--- a/src/app/_components/SearchBar/index.tsx
+++ b/src/app/_components/SearchBar/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import {
+  Button,
+  DateInput,
+  GroupCountInput,
+  LocationInput,
+  CommonForm,
+} from '@/src/app/_components';
+
+function SearchBar() {
+  return (
+    <div className='m-auto flex w-full max-w-1440pxr items-center justify-center bg-gray500 px-40pxr'>
+      <CommonForm
+        className='shadow-searchBar flex w-full max-w-1360pxr flex-col items-center justify-between rounded-lg bg-white px-0pxr pb-0pxr pt-20pxr tablet:px-28pxr tablet:py-32pxr desktop:flex-row desktop:gap-28pxr '
+        onSubmit={() => {}}
+      >
+        <div className='flex-center flex w-full flex-col gap-12pxr px-20pxr pb-20pxr tablet:flex-row tablet:px-0pxr desktop:pb-0pxr'>
+          <LocationInput />
+          <DateInput />
+          <GroupCountInput />
+        </div>
+        <Button type='search'>검색</Button>
+      </CommonForm>
+    </div>
+  );
+}
+
+export default SearchBar;

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -1,3 +1,9 @@
 export { default as Header } from './Header';
 export { default as Button } from './Button';
 export { default as Pagination } from './Pagination';
+export { default as CommonForm } from './Form/CommonForm';
+export { default as CommonInput } from './Input/CommonInput';
+export { default as LocationInput } from './Input/LocationInput';
+export { default as DateInput } from './Input/DateInput';
+export { default as GroupCountInput } from './Input/GroupCountInput';
+export { default as searchBar } from './SearchBar';

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,6 +131,6 @@ body {
     @apply flex-center flex h-64pxr w-318pxr rounded-[16px] bg-gray200 text-gray700 font-body1 hover:bg-primary50 hover:text-primary100 active:text-black disabled:bg-gray300 disabled:text-gray500 tablet:h-108pxr;
   }
   .button-search {
-    @apply flex-center flex h-64pxr w-182pxr rounded-md bg-primary100 text-white font-title3-bold hover:bg-primary50 hover:text-primary100 active:text-black disabled:bg-gray300  disabled:text-gray500 tablet:h-62pxr;
+    @apply flex-center flex h-64pxr w-full flex-shrink-0 rounded-md bg-primary100 text-white font-title3-bold hover:bg-primary50 hover:text-primary100  active:text-black disabled:bg-gray300 disabled:text-gray500 tablet:h-62pxr desktop:w-182pxr;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,6 +40,9 @@ const config: Config = {
         gradient:
           'linear-gradient(180deg, rgba(0, 0, 0, 0.00), rgba(0, 0, 0, 0.60) 75.9%)',
       },
+      boxShadow: {
+        searchBar: '0px 4px 23px 0px rgba(0, 0, 0, 0.07)',
+      },
       colors: {
         primary100: '#4F9E4F',
         primary50: '#C4DBC4',
@@ -66,6 +69,12 @@ const config: Config = {
     },
     fontFamily: {
       pre: 'Pretendard',
+    },
+    flex: {
+      '1': '1 1 0%',
+      '110': '1.10 1.10 0%',
+      '134': '1.34 1.34 0%',
+      '123': '1.23 1.23 0%',
     },
   },
   plugins: [


### PR DESCRIPTION
## 🛠️주요 변경 사항

- SearchBar 컴포넌트 UI 구현
- 리액트 훅 폼의 FormProvider로 공통 폼 컴포넌트 구현
- 리액트 훅 폼의 UseFormContext를 통한 공통 인풋 컴포넌트 구현(추후 내용 보충)

## 📣리뷰어에게 하고싶은 말

-공통 Input 컴포넌트를 먼저 구현하고, 이를 Import 및 커스텀 하여 검색바 내 Input 컴포넌트들을 구현해놓은 상황 
  입니다

## 🖼️스크린샷(선택)

https://github.com/teamCampro/campro_FE/assets/144667681/394036e9-a06c-427d-8af3-ba9d370c5cef

제 노트북 스크린샷이 이상하네요... 실제로는 각 Input 컴포넌트에 border는 잘들어가있습니다 




## ❗관련이슈

-
