### PR TITLE
fix: 마이페이지 디자인 QA 반영

### DIFF
--- a/public/svgs/index.ts
+++ b/public/svgs/index.ts
@@ -86,6 +86,7 @@ export { default as IconPersonalShower } from './personalShower.svg';
 export { default as IconPersonalToilet } from './personalToilet.svg';
 export { default as IconPet } from './pet.svg';
 export { default as IconPlay } from './play.svg';
+export { default as IconMinusNon } from './minus-non.svg';
 export { default as IconPlusNon } from './plus-non.svg';
 export { default as IconPlus } from './plus.svg';
 export { default as IconPublicToilet } from './publicToilet.svg';

--- a/public/svgs/minus-non.svg
+++ b/public/svgs/minus-non.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M18.8 12C18.8 12.4418 18.4419 12.8 18 12.8L6.00005 12.8C5.55822 12.8 5.20005 12.4418 5.20005 12C5.20005 11.5582 5.55822 11.2 6.00005 11.2L18 11.2C18.4419 11.2 18.8 11.5582 18.8 12Z" fill="current"/>
+</svg>

--- a/src/app/(header&footer)/reserve/_components/InfoAboutBookingPerson.tsx
+++ b/src/app/(header&footer)/reserve/_components/InfoAboutBookingPerson.tsx
@@ -33,19 +33,19 @@ function InfoAboutBookingPerson({
 
   return (
     <div className='flex flex-col gap-16pxr border-b border-gray200 pb-24pxr'>
-      <h3 className='text-black font-title3-semibold tabletMin:font-title1-semibold'>
+      <h3 className='leading-[160%] text-black font-title3-semibold tabletMin:font-title1-semibold'>
         예약자 정보
       </h3>
       <ul className='flex flex-col gap-16pxr'>
         <li className='flex items-center justify-start gap-40pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
           예약자명
-          <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+          <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
             {userInfo?.nickname}
           </span>
         </li>
         <li className='flex items-center justify-start gap-24pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
           휴대폰 번호
-          <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+          <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
             {userInfo?.phone}
           </span>
         </li>

--- a/src/app/(header&footer)/reserve/_components/InfoAboutReserve.tsx
+++ b/src/app/(header&footer)/reserve/_components/InfoAboutReserve.tsx
@@ -26,13 +26,13 @@ function InfoAboutReserve({ reservePersonInfo }: InfoAboutReserveType) {
   };
   return (
     <div className='flex flex-col gap-16pxr border-b border-gray200 pb-24pxr'>
-      <h3 className='text-black font-title3-semibold tabletMin:font-title1-semibold'>
+      <h3 className='leading-[160%] text-black font-title3-semibold tabletMin:font-title1-semibold'>
         예약 정보
       </h3>
-      <ul className='flex flex-col gap-16pxr'>
+      <ul className='flex flex-col gap-16pxr '>
         <li className='flex items-center justify-start gap-53pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
           인원
-          <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+          <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
             {reservePersonInfo
               ? `성인 ${reservePersonInfo.adult}명, 아이 ${reservePersonInfo.child}명`
               : `성인 ${searchParams.get('adult')}명, 아이 ${searchParams.get('child')}명`}
@@ -40,13 +40,13 @@ function InfoAboutReserve({ reservePersonInfo }: InfoAboutReserveType) {
         </li>
         <li className='flex items-center justify-start gap-53pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
           일정
-          <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+          <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
             {format()}
           </span>
         </li>
         <li className='flex items-center justify-start gap-53pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
           애견
-          <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+          <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
             {reservePersonInfo
               ? `${reservePersonInfo.pet}마리`
               : `${searchParams.get('pet')}마리`}

--- a/src/app/(header&footer)/reserve/_components/PaymentAmount.tsx
+++ b/src/app/(header&footer)/reserve/_components/PaymentAmount.tsx
@@ -43,14 +43,14 @@ function PaymentAmount({ sitePrice }: { sitePrice: number }) {
   }, [totalPaymentForOptions, dispatch]);
 
   return (
-    <div className='flex flex-col gap-12pxr border-b-2 border-dashed pb-24pxr'>
+    <div className='flex flex-col gap-12pxr border-b-2 border-dashed pb-20pxr'>
       <h3
-        className={`text-black  ${isProfile ? 'font-title1-semibold' : 'font-title3-semibold'}`}
+        className={`leading-[160%] text-black  ${isProfile ? 'font-title1-semibold' : 'font-title3-semibold'}`}
       >
         결제 금액
       </h3>
       <ul className='flex flex-col gap-12pxr'>
-        <li className='flex-center justify-between text-gray600 font-body2-medium'>
+        <li className='flex-center justify-between leading-[140%] text-gray600 font-body2-medium'>
           객실 1개 x
           {dateDiff(searchParams.get('checkIn'), searchParams.get('checkOut'))}
           박
@@ -69,7 +69,7 @@ function PaymentAmount({ sitePrice }: { sitePrice: number }) {
         </li>
       </ul>
       <ul className='flex flex-col gap-8pxr'>
-        <li className='flex-center justify-between text-gray600 font-body2-semibold '>
+        <li className='flex-center justify-between leading-[140%] text-gray600 font-body2-semibold'>
           추가 옵션
           <span className='whitespace-nowrap text-gray600 font-body2-semibold'>
             {totalPaymentForOptions.toLocaleString()}원

--- a/src/app/(header&footer)/reserve/_components/SiteInfo.tsx
+++ b/src/app/(header&footer)/reserve/_components/SiteInfo.tsx
@@ -14,6 +14,7 @@ export interface ReserveInfoData {
   childSiteName?: string;
   maxPeople: string;
   price: number;
+  siteImage: string;
 }
 
 interface SiteInfoType {
@@ -44,28 +45,28 @@ function SiteInfo({ size, siteInfo }: SiteInfoType) {
         className={`border-bg-gray300 flex-col gap-24pxr border-b ${SIZE_OPTION[size]}`}
       >
         <figure className='flex-center justify-start gap-16pxr tabletMin:gap-24pxr'>
-          {/* <div className='relative h-140pxr w-140pxr rounded-xl border'> */}
-          {/* <Image
-            src={campList.image}
-            width={140}
-            height={140}
-            alt='캠핑장 사이트 이미지'
-            className='rounded-xl'
-          /> */}
-
+          <div className='h-140pxr w-140pxr overflow-hidden rounded-xl'>
+            <Image
+              src={siteInfo.siteImage}
+              width={140}
+              height={140}
+              alt='캠핑장 사이트 이미지'
+              className='h-full w-full object-cover'
+            />
+          </div>
           <div className='flex flex-col'>
-            <h3 className='text-gray800 font-title2-semibold'>
+            <h3 className='leading-[160%] text-gray800 font-title2-semibold'>
               {siteInfo.name}
             </h3>
             <small className='flex text-gray500 font-caption2-medium'>
-              <div className='h-16pxr w-16pxr'>
+              {/* {<div className='h-16pxr w-16pxr'>
                 <IconStar width='100%' height='100%' viewBox='0 0 24 24' />
-              </div>
-              <span>{`7.2 (257)`}</span>
+              </div>} 
+              <span>{`7.2 (257)`}</span> */}
             </small>
             <ul className='mt-20pxr flex flex-col gap-8pxr'>
               <li className='flex  gap-4pxr '>
-                <h3 className='flex-center h-22pxr w-full justify-start !leading-none text-gray600 font-body2-medium'>
+                <h3 className='flex-center h-22pxr w-full justify-start gap-2pxr !leading-none text-gray600 font-body2-medium'>
                   <span className='inline-block h-20pxr w-20pxr'>
                     <IconLocation
                       width='100%'
@@ -74,11 +75,13 @@ function SiteInfo({ size, siteInfo }: SiteInfoType) {
                       fill='#949494'
                     />
                   </span>
-                  <div className='reserve-lineOver'>{siteInfo.address}</div>
+                  <div className='reserve-lineOver leading-[140%]'>
+                    {siteInfo.address}
+                  </div>
                 </h3>
               </li>
               <li className='flex gap-4pxr'>
-                <h3 className='flex-center justify-start !leading-none text-gray600 font-body2-medium '>
+                <h3 className='flex-center justify-start gap-2pxr !leading-none text-gray600 font-body2-medium'>
                   <span className='inline-block h-20pxr w-20pxr'>
                     <IconCall
                       width='100%'
@@ -87,18 +90,19 @@ function SiteInfo({ size, siteInfo }: SiteInfoType) {
                       fill='#949494'
                     />
                   </span>
-                  {siteInfo.tel}
+                  <div className='leading-[140%]'>{siteInfo.tel}</div>
                 </h3>
               </li>
             </ul>
           </div>
         </figure>
         <ul className='flex flex-col gap-12pxr pb-24pxr'>
-          <li className='flex-center justify-start gap-16pxr text-gray500 font-body2-semibold'>
+          <li className='flex-center justify-start gap-16pxr leading-[140%] text-gray500 font-body2-semibold'>
             예약 사이트
             <span className='flex-center gap-4pxr text-gray700 font-body1'>
               <h4 className='font-body1-bold'>
-                {siteInfo.parentSiteName} - {siteInfo.childSiteName}
+                {siteInfo.parentSiteName}
+                {siteInfo.childSiteName}
               </h4>
               <div
                 onClick={openModal}

--- a/src/app/(mypage)/profile/_components/ImageUpload.tsx
+++ b/src/app/(mypage)/profile/_components/ImageUpload.tsx
@@ -12,17 +12,26 @@ import { ImagesType, SurveyListsType } from './WriteReviewModal';
 interface ImageUploadType {
   surveyLists: SurveyListsType;
   setSurveyLists: Dispatch<SetStateAction<SurveyListsType>>;
+  maxFileCount: number;
 }
 
-function ImageUpload({ surveyLists, setSurveyLists }: ImageUploadType) {
+function ImageUpload({
+  surveyLists,
+  setSurveyLists,
+  maxFileCount,
+}: ImageUploadType) {
   let inputRef = useRef<HTMLInputElement>(null);
 
   const handleSaveImage = async (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     const tmpFileList: ImagesType[] = [];
     const files = e.target.files;
-
-    if (files && files.length < 6 && surveyLists.images.length < 5) {
+    console.log(surveyLists.images);
+    if (
+      files &&
+      files.length <= maxFileCount &&
+      surveyLists.images.length <= maxFileCount
+    ) {
       for (let i = 0; i < files.length; i++) {
         const preview_URL = URL.createObjectURL(files[i]);
         const fileType = files[i].type.split('/')[0];
@@ -59,7 +68,7 @@ function ImageUpload({ surveyLists, setSurveyLists }: ImageUploadType) {
         }
       }
     } else {
-      /* alert('이미지는 5장만 추가할 수 있습니다'); */
+      alert(`이미지는 ${maxFileCount}장만 추가할 수 있습니다`);
     }
     setSurveyLists({
       ...surveyLists,
@@ -112,7 +121,7 @@ function ImageUpload({ surveyLists, setSurveyLists }: ImageUploadType) {
                 />
               )}
               <div
-                className='absolute right-0pxr top-0pxr h-18pxr w-18pxr cursor-pointer'
+                className='absolute right-4pxr top-4pxr h-18pxr w-18pxr cursor-pointer'
                 onClick={() => deleteImage(index)}
               >
                 <IconClose
@@ -129,14 +138,16 @@ function ImageUpload({ surveyLists, setSurveyLists }: ImageUploadType) {
       <div className='flex-center'>
         <label
           htmlFor='reviewImage'
-          className={`flex-center flex h-56pxr w-108pxr cursor-pointer flex-nowrap gap-4pxr whitespace-nowrap rounded-[99px] border  py-24pxr pl-24pxr pr-32pxr  font-body2-semibold  ${surveyLists.images.length < 5 ? 'border-primary100 text-primary100 hover:bg-primary50' : 'bg-gray300 text-gray500'}`}
+          className={`flex-center flex h-56pxr w-108pxr cursor-pointer flex-nowrap gap-4pxr whitespace-nowrap rounded-[99px] border  py-24pxr pl-24pxr pr-32pxr  font-body2-semibold  ${surveyLists.images.length < maxFileCount ? 'border-primary100 text-primary100 hover:bg-primary50' : 'bg-gray300 text-gray500'}`}
         >
           <div className='h-20pxr w-20pxr '>
             <IconPlusNon
               width='100%'
               height='100%'
               viewBox='0 0 24 24'
-              fill={surveyLists.images.length < 5 ? '#4F9E4F' : '#949494'}
+              fill={
+                surveyLists.images.length < maxFileCount ? '#4F9E4F' : '#949494'
+              }
             />
           </div>
           <input
@@ -148,7 +159,7 @@ function ImageUpload({ surveyLists, setSurveyLists }: ImageUploadType) {
             accept='video/*, image/*'
             multiple
             onChange={handleSaveImage}
-            disabled={surveyLists.images.length < 5 ? false : true}
+            disabled={surveyLists.images.length < maxFileCount ? false : true}
           />
           추가
         </label>

--- a/src/app/(mypage)/profile/_components/ReserveInfo.tsx
+++ b/src/app/(mypage)/profile/_components/ReserveInfo.tsx
@@ -30,6 +30,7 @@ interface ReserveInfoType {
     status: string;
     userName: string;
     userPhone: string;
+    siteImage: string;
   };
 }
 
@@ -65,6 +66,7 @@ function ReserveInfo({ getDetailReserve }: ReserveInfoType) {
     status,
     userName,
     userPhone,
+    siteImage,
   } = getDetailReserve;
 
   const [isClose, setIsClose] = useState(false);
@@ -76,6 +78,8 @@ function ReserveInfo({ getDetailReserve }: ReserveInfoType) {
     parentSiteName: campingZoneSiteName,
     maxPeople: String(maxPeople),
     price: campingZoneSitePrice,
+    siteImage:
+      siteImage && siteImage.length > 0 ? JSON.parse(siteImage)[0] : '',
   };
 
   const reservePersonInfo: ReservePersonInfoType = {
@@ -98,7 +102,9 @@ function ReserveInfo({ getDetailReserve }: ReserveInfoType) {
   return (
     <>
       <div className='flex-center justify-between tabletMin:mb-32pxr'>
-        <h2 className='hidden font-h1-semibold tabletMin:block'>예약 상세</h2>
+        <h2 className='hidden leading-[140%] font-h1-semibold tabletMin:block'>
+          예약 상세
+        </h2>
         <Button.Round
           custom={`!w-108pxr bg-white border border-gray200 font-caption1-semibold !h-36pxr hidden tabletMin:flex !text-gray500 tabletMin:hover:!text-primary100 !rounded-md ${status == 'SERVICE_COMPLETE' || status == 'RESERVE_CANCEL' ? 'hidden' : ''}`}
           onClick={handleModal}
@@ -111,42 +117,42 @@ function ReserveInfo({ getDetailReserve }: ReserveInfoType) {
         <InfoAboutReserve reservePersonInfo={reservePersonInfo} />
         <InfoAboutBookingPerson userDecideInfo={userDecideInfo} />
         <div className='flex flex-col gap-16pxr border-b border-gray200 pb-24pxr'>
-          <h3 className='text-black font-title3-semibold tabletMin:font-title1-semibold'>
+          <h3 className='leading-[160%] text-black font-title3-semibold tabletMin:font-title1-semibold'>
             차량 추가
           </h3>
           <div className='flex items-center justify-start gap-24pxr text-gray500 font-caption1-semibold tabletMin:font-body2-semibold'>
             차량번호
-            <span className='text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
+            <span className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-bold'>
               {carInfo}
             </span>
           </div>
         </div>
         <div className='flex flex-col gap-16pxr border-b border-gray200 pb-24pxr'>
-          <h3 className=' text-black font-title3-semibold tabletMin:font-title1-semibold'>
+          <h3 className=' leading-[160%] text-black font-title3-semibold tabletMin:font-title1-semibold'>
             추가 옵션
           </h3>
           <ul className='flex flex-col gap-16pxr'>
-            <li className='text-gray800 font-body2-semibold tabletMin:font-body1-medium'>
+            <li className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-medium '>
               숫불 세트(고기2인분+식기)
             </li>
-            <li className='text-gray800 font-body2-semibold tabletMin:font-body1-medium'>
+            <li className='leading-[140%] text-gray800 font-body2-semibold tabletMin:font-body1-medium'>
               장작 세트
             </li>
           </ul>
         </div>
         <div className='flex flex-col justify-between tabletMin:flex-row'>
           <div className='moblie:border-b flex w-full flex-col gap-16pxr pb-24pxr tabletMin:border-r tabletMin:pr-32pxr'>
-            <h3 className='text-black font-title3-semibold tabletMin:font-title1-semibold'>
+            <h3 className='leading-[160%] text-black font-title3-semibold tabletMin:font-title1-semibold'>
               결제 정보
             </h3>
             <ul className='flex flex-col gap-12pxr'>
-              <li className='flex-center justify-start gap-35pxr text-gray600 font-body2-medium'>
+              <li className='flex-center justify-start gap-35pxr leading-[140%] text-gray500 font-body2-semibold'>
                 <h4 className='whitespace-nowrap'>결제 일시</h4>
                 <span className='text-gray800 font-body2-medium'>
                   {getOneFormatDate(reservedAt, true)}
                 </span>
               </li>
-              <li className='flex-center justify-start gap-35pxr text-gray600 font-body2-medium'>
+              <li className='flex-center justify-start gap-35pxr leading-[140%] text-gray500 font-body2-semibold'>
                 <h4 className='whitespace-nowrap'>결제 수단</h4>
                 <span className='text-gray800 font-body2-medium'>
                   {/* 현대 ****-****-**21 */}
@@ -157,7 +163,7 @@ function ReserveInfo({ getDetailReserve }: ReserveInfoType) {
           </div>
           <div className='flex w-full flex-col gap-12pxr tabletMin:pl-32pxr'>
             <PaymentAmount sitePrice={40000} />
-            <div className='flex justify-between text-black font-body2-semibold'>
+            <div className='flex justify-between leading-[140%] text-black font-body2-semibold'>
               <h2>총 결제금액</h2>
               <h2>130,000원</h2>
             </div>

--- a/src/app/(mypage)/profile/_components/ReserveItem.tsx
+++ b/src/app/(mypage)/profile/_components/ReserveItem.tsx
@@ -41,7 +41,7 @@ function ReserveItem({ list, reserveState, status }: ReserveItemType) {
   return (
     <>
       <figure
-        className={`flex flex-col justify-start gap-24pxr rounded-xl border p-24pxr tabletMin:flex-row`}
+        className={`flex flex-col justify-start gap-16pxr rounded-xl border p-24pxr tabletMin:flex-row tabletMin:gap-24pxr`}
       >
         <Image
           src={'' /* list.image */}
@@ -51,33 +51,33 @@ function ReserveItem({ list, reserveState, status }: ReserveItemType) {
           className='rounded-xl'
         />
         <div className='flex w-full flex-col justify-between mobile:gap-20pxr tabletMin:flex-row'>
-          <div className='profile-width flex w-full flex-col gap-16pxr'>
+          <div className='profile-width flex w-full flex-col gap-12pxr'>
             <div className=''>
-              <h3 className='text-primary100 font-body2-bold'>
-                {checkState(status)}
+              <h3 className='leading-[140%] text-primary100 font-body2-bold'>
+                {'예약 대기' || checkState(status)}
               </h3>
-              <h2 className='profile-lineOver whitespace-nowrap text-gray800 font-title1-bold'>
+              <h2 className='profile-lineOver whitespace-nowrap leading-[160%] text-gray800 font-title1-bold'>
                 {list.campingZoneName}
               </h2>
-              <div className='text-gray600 font-body2-medium'>
+              <div className='leading-[140%] text-gray600 font-body2-medium'>
                 {list.campingZoneSiteName}
               </div>
             </div>
             <div className='flex items-end justify-start gap-16pxr'>
-              <div>
-                <small className='text-gray500 font-caption2-semibold'>
+              <div className='flex flex-col'>
+                <small className='leading-[140%] text-gray500 font-caption2-semibold'>
                   입실
                 </small>
-                <h3 className='text-800 font-body1-bold'>
+                <h3 className='text-800 leading-[140%] font-body1-bold'>
                   {getOneFormatDate(list.stayStartAt)}
                 </h3>
               </div>
-              <div className='text-800 font-title3-bold'>-</div>
-              <div>
-                <small className='text-gray500 font-caption2-semibold'>
+              <div className='text-800 leading-[140%] font-title3-bold'>-</div>
+              <div className='flex flex-col'>
+                <small className='leading-[140%] text-gray500 font-caption2-semibold'>
                   퇴실
                 </small>
-                <h3 className='text-800 font-body1-bold'>
+                <h3 className='text-800 leading-[140%] font-body1-bold'>
                   {getOneFormatDate(list.stayEndAt)}
                 </h3>
               </div>

--- a/src/app/(mypage)/profile/_components/ReserveList.tsx
+++ b/src/app/(mypage)/profile/_components/ReserveList.tsx
@@ -6,6 +6,12 @@ import ReserveStateLists from './ReserveStateLists';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Loading } from '@/components/index';
+import Link from 'next/link';
+import {
+  IconArrowRight,
+  IconArrowRightNon,
+  IconArrowRightNormal,
+} from '@/public/svgs';
 
 export interface ReserveStateType {
   id: number;
@@ -23,29 +29,47 @@ function ReserveList({ userReserveData, status }: ReserveListType) {
     { id: 1, name: '전체', status: 'all' },
     { id: 2, name: '예약대기', status: 'RESERVE_WAITING' },
     { id: 3, name: '예약완료', status: 'RESERVE_COMPLETE' },
-    { id: 4, name: '이용완료', status: 'SERVICE_COMPLETE' },
-    { id: 5, name: '예약취소', status: 'RESERVE_CANCEL' },
+    { id: 4, name: '예약취소', status: 'RESERVE_CANCEL' },
+    { id: 5, name: '이용완료', status: 'SERVICE_COMPLETE' },
   ]);
 
-  if (!userReserveData) return <Loading />;
   return (
     <>
       <h2 className='mb-24pxr hidden font-title1-bold tabletMin:block'>
         예약내역
       </h2>
       <ReserveStateLists status={status} reserveState={reserveState} />
-      <div className='flex flex-col gap-16pxr '>
-        {userReserveData.map((list) => {
-          return (
-            <ReserveItem
-              key={list.id}
-              reserveState={reserveState}
-              list={list}
-              status={status}
-            />
-          );
-        })}
-      </div>
+      {userReserveData ? (
+        <div className='flex flex-col gap-16pxr '>
+          {userReserveData.map((list) => {
+            return (
+              <ReserveItem
+                key={list.id}
+                reserveState={reserveState}
+                list={list}
+                status={status}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className='flex-center flex-col gap-20pxr pt-108pxr mobile:pt-24pxr'>
+          <div className='mobile:flex-center mobile:flex-col'>
+            <h2 className='text-32pxr leading-[160%] text-gray600 font-h2-semibold mobile:text-22pxr mobile:font-title2-semibold'>
+              아직 예약 내역이 없어요
+            </h2>
+            <p className='text-18pxr leading-[140%] text-gray500 font-body1-medium mobile:text-14pxr mobile:font-caption1-medium'>
+              나에게 맞는 캠핑장을 찾아보는 건 어떨까요?
+            </p>
+          </div>
+          <Link className='mobile:hidden' href='/'>
+            <button className='flex-center gap-4pxr rounded-full border border-gray300 py-12pxr pl-20pxr pr-14pxr leading-[140%] text-gray600 font-body2-semibold'>
+              캠핑장 예약하기
+              <IconArrowRightNon fill='#949494' className='text-gray500' />
+            </button>
+          </Link>
+        </div>
+      )}
     </>
   );
 }

--- a/src/app/(mypage)/profile/_components/ReserveStateLists.tsx
+++ b/src/app/(mypage)/profile/_components/ReserveStateLists.tsx
@@ -36,17 +36,17 @@ function ReserveStateLists({
         },
       }}
     >
-      <ul className='flex justify-start gap-12pxr text-gray600 font-body2-semibold'>
+      <ul className='flex justify-start gap-12pxr text-gray600'>
         {reserveState.map((list) => {
           return (
             <SwiperSlide
               key={list.id}
               style={{ width: 'auto', display: 'inline-block' }}
-              className={`h-46pxr w-68pxr cursor-pointer rounded-full border  hover:border-primary100 hover:text-primary100 ${status === list.status ? 'border-primary100 text-primary100' : 'border-gray300 text-gray600'}`}
+              className={`h-46pxr w-68pxr cursor-pointer rounded-full border hover:border-primary100 hover:text-primary100 ${status === list.status ? 'border-primary100 text-primary100 font-body2-bold' : 'border-gray300 text-gray600 font-body2-semibold'}`}
             >
               <li /* className='h-46pxr w-68pxr' */>
                 <Link
-                  className='inline-block  h-full w-full px-20pxr py-12pxr'
+                  className='inline-block h-full w-full px-20pxr py-12pxr'
                   href={getStatusQuery(list.status)}
                 >
                   {list.name}

--- a/src/app/(mypage)/profile/_components/Score.tsx
+++ b/src/app/(mypage)/profile/_components/Score.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { IconStarHalf, IconStarScore } from '@/public/svgs';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { SurveyListsType } from './WriteReviewModal';
 
 interface ScoreType {
@@ -30,6 +30,11 @@ function Score({ setSurveyLists, surveyLists, score, setScore }: ScoreType) {
     }
   };
 
+  useEffect(() => {
+    setSurveyLists({ ...surveyLists, score: score });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [score, setSurveyLists]);
+
   return (
     <>
       <div className='flex-center'>
@@ -45,24 +50,24 @@ function Score({ setSurveyLists, surveyLists, score, setScore }: ScoreType) {
               Math.floor(score) === index ? (
                 <>
                   <IconStarScore
-                    key={index}
+                    key={`star_${index}`}
                     width='100%'
                     height='100%'
                     viewBox='0 0 37 36'
                     fill='#DFDFDF'
                   />
                   <IconStarHalf
-                    key={index}
+                    key={`half_${index}`}
                     width='100%'
                     height='100%'
                     viewBox='0 0 37 36'
-                    fill='gold'
+                    fill='#FFAD0A'
                     className='absolute left-0pxr top-0pxr'
                   />
                 </>
               ) : index + 1 > score ? (
                 <IconStarScore
-                  key={index}
+                  key={`star_${index}`}
                   width='100%'
                   height='100%'
                   viewBox='0 0 37 36'
@@ -71,11 +76,11 @@ function Score({ setSurveyLists, surveyLists, score, setScore }: ScoreType) {
                 />
               ) : (
                 <IconStarScore
-                  key={index}
+                  key={`star_${index}`}
                   width='100%'
                   height='100%'
                   viewBox='0 0 37 36'
-                  fill='gold'
+                  fill='#FFAD0A'
                   className='absolute'
                 />
               )}

--- a/src/app/(mypage)/profile/_components/Survey.tsx
+++ b/src/app/(mypage)/profile/_components/Survey.tsx
@@ -1,12 +1,17 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import Score from './Score';
 import Button from '@/components/Button';
-import { IconPlusNon } from '@/public/svgs';
+import {
+  IconMapMinus,
+  IconMinus,
+  IconMinusNon,
+  IconPlusNon,
+} from '@/public/svgs';
 import { ReviewKeywordType, SurveyListsType } from './WriteReviewModal';
 
 interface SurveyType {
-  isScroll: boolean;
-  handleScroll: () => void;
+  isToggleScroll: boolean;
+  handleToggleScroll: () => void;
   setSurveyLists: Dispatch<SetStateAction<SurveyListsType>>;
   surveyLists: SurveyListsType;
   keywords: ReviewKeywordType[];
@@ -16,8 +21,8 @@ interface SurveyType {
 }
 
 function Survey({
-  isScroll,
-  handleScroll,
+  isToggleScroll,
+  handleToggleScroll,
   setSurveyLists,
   surveyLists,
   keywords,
@@ -55,7 +60,9 @@ function Survey({
   return (
     <>
       <div className='mt-24pxr flex flex-col gap-8pxr'>
-        <h3 className='text-black font-body1-bold'>전체 만족도는 어땠나요?</h3>
+        <h3 className='leading-[140%] text-black font-body1-bold'>
+          전체 만족도는 어땠나요?
+        </h3>
         <Score
           setSurveyLists={setSurveyLists}
           surveyLists={surveyLists}
@@ -64,29 +71,51 @@ function Survey({
         />
       </div>
       <div className='mt-24pxr'>
-        <h3 className='text-black font-body1-bold'>어떤 점이 좋았나요?</h3>
-        <h4 className='mt-4pxr text-gray500 font-caption1-medium'>
+        <h3 className='leading-[140%] text-black font-body1-bold'>
+          어떤 점이 좋았나요?
+        </h3>
+        <h4 className='mt-4pxr leading-[140%] text-gray500 font-caption1-medium'>
           이 캠핑장에 어울리는 키워드를 최대 3개까지 골라주세요
         </h4>
-        <ul
-          className={`mypage mt-16pxr grid h-212pxr justify-between gap-12pxr  ${isScroll ? '' : 'overflow-hidden'}`}
-        >
-          {keywords.map((keyword) => {
-            return (
-              <Button.Round
-                key={keyword.id}
-                size='lg'
-                custom={`${keyword.isDone ? 'bg-primary50 text-primary100 border border-primary100' : ''} hover:font-caption1-semibold hover:border hover:border-primary100 !w-full !h-44pxr rounded-lg font-caption1-medium text-gray600`}
-                onClick={() => handleClick(keyword)}
-              >
-                {keyword.keyword}
-              </Button.Round>
-            );
-          })}
-        </ul>
+        <div>
+          <ul
+            className={`mypage  mt-16pxr grid  justify-between gap-12pxr  ${isToggleScroll ? 'h-full' : 'h-212pxr overflow-hidden'}`}
+          >
+            {keywords.map((keyword) => {
+              return (
+                <Button.Round
+                  key={keyword.id}
+                  size='lg'
+                  custom={`${keyword.isDone ? 'bg-primary50 text-primary100 border border-primary100' : ''} hover:font-caption1-semibold hover:border hover:border-primary100 !w-full !h-44pxr rounded-lg font-caption1-medium text-gray600`}
+                  onClick={() => handleClick(keyword)}
+                >
+                  {keyword.keyword}
+                </Button.Round>
+              );
+            })}
+          </ul>
+          <div
+            className={`flex-center bottom-10pxr mt-12pxr  ${isToggleScroll ? '' : 'hidden'}`}
+            onClick={handleToggleScroll}
+          >
+            <button className='flex-center flex h-44pxr flex-nowrap gap-4pxr rounded-[99px] border border-gray300 px-20pxr py-12pxr text-gray500 font-body2-medium'>
+              <div className='h-20pxr w-20pxr'>
+                <IconMinusNon
+                  width='100%'
+                  height='100%'
+                  viewBox='0 0 24 24'
+                  fill='#949494'
+                />
+              </div>
+              <span className='whitespace-nowrap leading-[140%] font-caption1-medium'>
+                접기
+              </span>
+            </button>
+          </div>
+        </div>
         <div
-          className={`flex-center mt-12pxr ${isScroll ? 'hidden' : ''}`}
-          onClick={handleScroll}
+          className={`flex-center mt-12pxr ${isToggleScroll ? 'hidden' : ''}`}
+          onClick={handleToggleScroll}
         >
           <button className='flex-center flex h-44pxr flex-nowrap gap-4pxr rounded-[99px] border border-gray300 px-20pxr py-12pxr text-gray500 font-body2-medium'>
             <div className='h-20pxr w-20pxr'>
@@ -97,8 +126,8 @@ function Survey({
                 fill='#949494'
               />
             </div>
-            <span className='whitespace-nowrap font-caption1-medium'>
-              더보기
+            <span className='whitespace-nowrap leading-[140%] font-caption1-medium'>
+              더 보기
             </span>
           </button>
         </div>

--- a/src/app/(mypage)/profile/_components/WriteReview.tsx
+++ b/src/app/(mypage)/profile/_components/WriteReview.tsx
@@ -26,18 +26,21 @@ function WriteReview({
   return (
     <>
       <div className='mt-24pxr flex flex-col'>
-        <h3 className='mb-8pxr text-black font-body1-bold'>
-          이용 사진/영상이 있으신가요?
+        <h3 className='mb-8pxr leading-[140%] text-black font-body1-bold'>
+          사진/영상을 등록해주세요
         </h3>
         <ImageUpload
           surveyLists={surveyLists}
           setSurveyLists={setSurveyLists}
+          maxFileCount={4}
         />
         <div className='mt-24pxr flex flex-col gap-12pxr'>
-          <h3 className='text-black font-body1-bold'>후기를 작성해 주세요</h3>
+          <h3 className='leading-[140%] text-black font-body1-bold'>
+            후기를 작성해 주세요
+          </h3>
           <textarea
             placeholder={`리뷰 작성 시 주의해주세요\n리뷰를 보는 사용자와 사업자에게\n욕설, 비방,명예훼손성 표현은 자제해 주세요.`}
-            className='h-200pxr w-full resize-none rounded-lg border-none bg-gray100 p-16pxr outline-none placeholder:font-body2-medium'
+            className='h-200pxr w-full resize-none rounded-lg border border-gray100 bg-gray100 p-16pxr outline-none placeholder:font-body2-medium focus:border focus:border-primary100'
             value={writeReview}
             onChange={handleChange}
             onBlur={handleBlur}

--- a/src/app/(mypage)/profile/_components/WriteReviewModal.tsx
+++ b/src/app/(mypage)/profile/_components/WriteReviewModal.tsx
@@ -36,7 +36,7 @@ export interface SurveyListsType {
 
 function WriteReviewModal({ handleClick }: WriteReviewModalType) {
   const [isNext, setisNext] = useState(false);
-  const [isScroll, setIsScroll] = useState(false);
+  const [isToggleScroll, setToggleScroll] = useState(false);
   const [writeReview, setWriteReview] = useState('');
   const [score, setScore] = useState<number>(0);
   const [keywords, setKeywords] = useState<ReviewKeywordType[]>([
@@ -70,8 +70,8 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
   };
 
   /* 더보기 */
-  const handleScroll = () => {
-    setIsScroll(true);
+  const handleToggleScroll = () => {
+    setToggleScroll(!isToggleScroll);
   };
 
   const handleButton = () => {
@@ -129,7 +129,7 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
           </h2>
           <div className='flex h-full w-full flex-col justify-between gap-32pxr'>
             <div
-              className={`flex h-full flex-col ${isScroll ? 'scrollbar-hide overflow-y-scroll' : ''}  px-16pxr  pt-16pxr tabletMin:px-28pxr tabletMin:pt-24pxr`}
+              className={`flex h-full flex-col ${isToggleScroll ? 'scrollbar-hide overflow-y-scroll' : ''} px-16pxr pt-16pxr tabletMin:px-28pxr tabletMin:pt-24pxr`}
             >
               <div
                 className='hidden h-24pxr w-24pxr cursor-pointer tabletMin:block'
@@ -142,23 +142,23 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
                   fill='white'
                 />
               </div>
-              <h3 className='text-black font-title2-semibold tabletMin:mt-24pxr'>
+              <h3 className='leading-[160%] text-black font-title2-semibold tabletMin:mt-16pxr'>
                 자연숲 캠핑장은 어떠셨나요?
               </h3>
-              <h4 className='mb-20pxr mt-2pxr text-gray500 font-caption1-medium'>
+              <h4 className='mb-20pxr mt-2pxr leading-[140%] text-gray500 font-caption1-medium'>
                 캠핑장 이용 경험을 공유해 주세요
               </h4>
               <ul
                 className={`flex flex-col gap-4pxr ${isNext ? '' : 'rounded-lg bg-gray100 px-16pxr py-12pxr'}`}
               >
-                <li className='text-gray500 font-caption1-medium'>
-                  객실명: <span>A사이드 | A1-8구역</span>
+                <li className='leading-[140%] text-gray500 font-caption1-medium'>
+                  객실명: <span>A1-8구역</span>
                 </li>
-                <li className='text-gray500 font-caption1-medium'>
+                <li className='leading-[140%] text-gray500 font-caption1-medium'>
                   유형: <span>2인</span>
                 </li>
                 {isNext ? (
-                  <li>
+                  <li className='pt-4pxr'>
                     <ul className='flex-center flex-wrap justify-start gap-4pxr'>
                       <li className='flex-center bg-gray100 px-6pxr py-2pxr !leading-none text-gray600 font-caption2-medium'>
                         <div className='w-16xpr h-16pxr'>
@@ -174,7 +174,7 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
                         return (
                           <li
                             key={index}
-                            className='whitespace-nowrap bg-gray100 px-6pxr py-2pxr text-gray600 font-caption2-medium'
+                            className='whitespace-nowrap bg-gray100 px-6pxr py-2pxr leading-[140%] text-gray600 font-caption2-medium'
                           >
                             {list}
                           </li>
@@ -194,8 +194,8 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
               ) : (
                 <Survey
                   setSurveyLists={setSurveyLists}
-                  isScroll={isScroll}
-                  handleScroll={handleScroll}
+                  isToggleScroll={isToggleScroll}
+                  handleToggleScroll={handleToggleScroll}
                   surveyLists={surveyLists}
                   {...propsList}
                 />
@@ -203,11 +203,11 @@ function WriteReviewModal({ handleClick }: WriteReviewModalType) {
             </div>
             <div className='flex-center h-88pxr justify-between gap-14pxr border-t border-b-white px-20pxr py-16pxr'>
               <div
-                className='flex-center cursor-pointer gap-4pxr whitespace-nowrap pl-12pxr pr-6pxr text-gray500 font-title3-semibold'
+                className='flex-center cursor-pointer gap-4pxr whitespace-nowrap pl-12pxr pr-6pxr text-gray500 font-body1-medium'
                 onClick={handleReset}
               >
                 초기화
-                <div className='h-24pxr w-24pxr'>
+                <div className='h-18pxr w-18pxr text-[#C8C8C8]'>
                   <IconReset
                     width='100%'
                     height='100%'

--- a/src/app/(mypage)/profile/layout.tsx
+++ b/src/app/(mypage)/profile/layout.tsx
@@ -23,7 +23,7 @@ function Layout({ children }: LayoutType) {
         <section className='border-r border-gray200 mobile:hidden'>
           <SideLists />
         </section>
-        <section className='scrollbar-hide p-20pxr tabletMin:overflow-y-auto tabletMin:p-40pxr'>
+        <section className='scrollbar-hide px-20pxr pb-48pxr pt-20pxr tabletMin:overflow-y-auto tabletMin:px-40pxr tabletMin:pb-48pxr tabletMin:pt-40pxr'>
           {children}
         </section>
       </main>


### PR DESCRIPTION
## 🛠️주요 변경 사항

### 마이페이지 (처음화면)

- [x]  예약 내역 버튼 전체, 예약 대기, 예약 완료, 예약 취소, 이용 완료 순으로  배치
- [x]  버튼 스타일 다시 확인
- [x]  입실 퇴실쪽 ‘-’  을 body1-bold로 바꾸기
- [x]  입실과 날짜, 퇴실과 날짜 디브 마진 제거( 라인 하이트 제거하면 해결됨)
- [x]  예약 내역 없을 시 렌더링 되는 것 (디자이너님이 추가해주심)

### 예약 상세

- [x]  별, 별점, 댓글 (후기 작성이 없을 때는 렌더링 x)
- [x]  예약 상세 내  이미지 디자인에 맞게 크기 조정( 피그마 참고)
- [x]  결제 정보 내 결제 수단은 피그마 참고하여 있어보이게 수정
- [x]  footer 위로 마진 (메인페이지랑 마진 같도록)

### 후기

- [x]  더보기 버튼 아이콘 글씨랑 중앙정렬
- [x]  후기 타이틀 마진 탑 16px로 바꾸기
- [x]  별점 입력 전에는 0.0/5 라는 숫자 렌더링 안됨 입력하면 해당 분수 렌더링되도록
- [x]  별점 클릭 시 나오는 컬러 피그마대로 수정
- [x]  별점 모바일 사이즈에서 제대로 작동하지 않는 문제  
- [x]  +더보기 버튼 클릭하면 키워드 추가적으로 나옴 이 때는 - 접기 버튼으로 바뀌어야됨
반대도 마찬가지
- [x]  초기화 글자 body1-medium으로 변경 + 아이콘 크기18x18로 변경 + 아이콘 색상 피그마 참고하여 수정
- [x]  후기를 작성하는 쪽 디브에서 유형과 태그 사이 마진을 4px에서 8px로 변경
- [x]  후기를 작성하는 쪽 디브에서 ‘이용 사진/영상 있으신가요?’ 를
’사진/영상을 등록해주세요’ 로 변경
- [x]  사진/영상 추가 버튼에서 아이콘과 텍스트 gap 피그마대로 수정
- [x]  사진/영상 추가 갯수 4개 제한
- [x]  사진 추가 후 형태 정사각형으로 수정  각 사진 x아이콘 위치 (피그마 참고하여 수정)
- [x]  후기 작성 칸에 포커스 시 볼더 색깔 primary100 되도록 수정

## 📣리뷰어에게 하고싶은 말

- 혹시나 반영되지 않은 부분 있으면 말씀부탁드리겠습니다.
-  모바일에서 페이지 전체 높이 줄어들면 초기화 쪽 버튼 부분 가려지는 문제는 반영되어있지 않습니다.

## 🖼️스크린샷(선택)

## ❗관련이슈

- close #230 
