### PR TITLE
[#299] fix: 캠핑장 등록 카테고리 버튼 이미지 안나오는 문제

### DIFF
--- a/src/app/(owner)/_constants/ownerCampingCategories.tsx
+++ b/src/app/(owner)/_constants/ownerCampingCategories.tsx
@@ -23,7 +23,7 @@ const CAMPING_CATEGORIES = [
     buttonText: '카라반',
   },
   {
-    image: <IconAutoCamping className='scale-[2]' />,
+    image: <IconAutoCamping className='fill-black' />,
     buttonText: '오토 캠핑',
   },
   {


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 캠핑장 등록 카테고리 버튼 이미지 안나오는 문제 해결

## 📣리뷰어에게 하고싶은 말

-

## 🖼️스크린샷(선택)

## ❗관련이슈

- closed #299
